### PR TITLE
Add Anime Meta-Aggregator with Scraping Features

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Anime Meta-Aggregator - README</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container my-4">
+  <h1>Anime Meta-Aggregator</h1>
+  <p class="text-secondary">PHP + cURL + DOM + HTML/CSS/JS using CDN assets</p>
+
+  <h2>What is this?</h2>
+  <p>
+    A minimal demo that searches multiple providers for anime metadata (title, link, thumbnail, synopsis) and shows unified results.
+    It does not re-host streams or bypass DRM. It is intended for discovery only.
+  </p>
+
+  <h2>Features</h2>
+  <ul>
+    <li>Search across multiple providers</li>
+    <li>Server-side cURL requests with caching</li>
+    <li>DOM parsing example (Anime News Network)</li>
+    <li>Open API provider example (Kitsu)</li>
+    <li>Bootstrap UI via jsDelivr, icons via cdnjs</li>
+  </ul>
+
+  <h2>Run locally</h2>
+  <ol>
+    <li>Ensure PHP 8+ is installed with cURL extension enabled.</li>
+    <li>Serve this folder via PHP’s built-in server:
+      <pre>php -S 127.0.0.1:8000</pre>
+    </li>
+    <li>Open <a href="http://127.0.0.1:8000/">http://127.0.0.1:8000/</a> in your browser.</li>
+  </ol>
+
+  <h2>Providers</h2>
+  <ul>
+    <li><strong>Kitsu</strong>: Uses their public API via cURL.</li>
+    <li><strong>Anime News Network</strong>: Scrapes HTML with DOMDocument and XPath.</li>
+  </ul>
+
+  <p class="alert alert-warning">
+    Many popular streaming sites use anti-bot protections (e.g., Cloudflare) or prohibit scraping in their Terms.
+    Server-side cURL alone may not work for those. This demo intentionally avoids prohibited scraping and adult content.
+  </p>
+
+  <h2>Adding a new provider</h2>
+  <ol>
+    <li>Create a file in <code>providers/</code> that implements <code>ProviderInterface</code>.</li>
+    <li>Use <code>HttpClient</code> for network calls and, if scraping HTML, <code>DOMDocument</code>/<code>DOMXPath</code> to parse.</li>
+    <li>Add your provider to <code>api/search.php</code> providers array.</li>
+  </ol>
+
+  <h3>Provider skeleton</h3>
+  <pre><code>&lt;?php
+require_once __DIR__ . '/../lib/HttpClient.php';
+require_once __DIR__ . '/ProviderInterface.php';
+
+class MyProvider implements ProviderInterface {
+  private HttpClient $http;
+  public function __construct() {
+    $this-&gt;http = new HttpClient();
+  }
+  public function name(): string { return 'MyProvider'; }
+  public function search(string $query): array {
+    $res = $this-&gt;http-&gt;get('https://example.com/search?q=' . rawurlencode($query));
+    if (!$res['ok'] || $res['status'] !== 200) return [];
+    $doc = new DOMDocument();
+    @$doc-&gt;loadHTML($res['body']);
+    $xpath = new DOMXPath($doc);
+    // Parse and map results...
+    return [];
+  }
+}
+</code></pre>
+
+  <h2>Legal and ethical</h2>
+  <ul>
+    <li>Respect each website’s Terms of Service and robots.txt.</li>
+    <li>Do not scrape or redistribute copyrighted content unlawfully.</li>
+    <li>This project is for educational purposes and metadata aggregation only.</li>
+  </ul>
+
+  <p class="text-secondary small mt-4">© Demo</p>
+</body>
+</html>

--- a/api/search.php
+++ b/api/search.php
@@ -1,0 +1,56 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+
+require_once __DIR__ . '/../providers/ProviderInterface.php';
+require_once __DIR__ . '/../providers/KitsuProvider.php';
+require_once __DIR__ . '/../providers/ANNProvider.php';
+
+$q = isset($_GET['q']) ? trim((string)$_GET['q']) : '';
+if ($q === '') {
+    echo json_encode(['results' => [], 'error' => 'EMPTY_QUERY'], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+// Initialize providers
+$providers = [
+    new KitsuProvider(),
+    new ANNProvider(),
+];
+
+// Aggregate results (sequential to keep it simple; can be optimized with curl_multi)
+$results = [];
+foreach ($providers as $p) {
+    try {
+        $items = $p->search($q);
+        // Normalize and guard
+        foreach ($items as $it) {
+            $results[] = [
+                'title' => (string)($it['title'] ?? 'Untitled'),
+                'url' => isset($it['url']) ? (string)$it['url'] : null,
+                'thumbnail' => $it['thumbnail'] ?? null,
+                'description' => $it['description'] ?? null,
+                'provider' => $it['provider'] ?? $p->name(),
+            ];
+        }
+    } catch (Throwable $e) {
+        // Continue on provider failure
+        // You can log $e if desired
+    }
+}
+
+// Deduplicate by title+provider+url
+$uniq = [];
+$out = [];
+foreach ($results as $r) {
+    $key = md5(($r['title'] ?? '') . '|' . ($r['provider'] ?? '') . '|' . ($r['url'] ?? ''));
+    if (!isset($uniq[$key])) {
+        $uniq[$key] = true;
+        $out[] = $r;
+    }
+}
+
+// Limit output
+$out = array_slice($out, 0, 48);
+
+echo json_encode(['results' => $out], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,15 @@
+/* Minimal custom styles */
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-img-top {
+  object-fit: cover;
+  height: 260px;
+}
+
+#alerts .alert + .alert {
+  margin-top: .75rem;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,75 @@
+(function () {
+  const q = document.getElementById('q');
+  const searchBtn = document.getElementById('searchBtn');
+  const clearBtn = document.getElementById('clearBtn');
+  const resultsEl = document.getElementById('results');
+  const alertsEl = document.getElementById('alerts');
+
+  function alert(msg, type = 'info') {
+    const el = document.createElement('div');
+    el.className = `alert alert-${type}`;
+    el.textContent = msg;
+    alertsEl.appendChild(el);
+    setTimeout(() => el.remove(), 5000);
+  }
+
+  function card(item) {
+    const thumb = item.thumbnail || 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f3a5.svg';
+    return `
+      <div class="col">
+        <div class="card h-100 shadow-sm">
+          <img src="${thumb}" class="card-img-top" alt="${escapeHtml(item.title || 'Anime')}">
+          <div class="card-body d-flex flex-column">
+            <h6 class="card-title">${escapeHtml(item.title || 'Untitled')}</h6>
+            <p class="card-text small text-secondary flex-grow-1">${escapeHtml(item.description || '').slice(0, 160)}</p>
+            <div class="d-flex justify-content-between align-items-center">
+              <span class="badge text-bg-light">${escapeHtml(item.provider)}</span>
+              ${item.url ? `<a class="btn btn-sm btn-primary" href="${item.url}" target="_blank" rel="noopener">Open</a>` : ''}
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function escapeHtml(s) {
+    if (!s) return '';
+    return s.replace(/[&<>"']/g, m =&gt; ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));
+  }
+
+  async function doSearch() {
+    const term = (q.value || '').trim();
+    if (!term) {
+      alert('Enter a search term.', 'warning');
+      q.focus();
+      return;
+    }
+    alertsEl.innerHTML = '';
+    resultsEl.innerHTML = '<div class="text-center py-5 w-100"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></div>';
+
+    try {
+      const res = await axios.get(`api/search.php?q=${encodeURIComponent(term)}`);
+      const items = res.data?.results || [];
+      if (!Array.isArray(items) || items.length === 0) {
+        resultsEl.innerHTML = '<div class="text-center text-secondary py-5 w-100">No results.</div>';
+        return;
+      }
+      resultsEl.innerHTML = items.map(card).join('');
+    } catch (e) {
+      console.error(e);
+      resultsEl.innerHTML = '';
+      alert('Search failed. See console for details.', 'danger');
+    }
+  }
+
+  searchBtn.addEventListener('click', doSearch);
+  clearBtn.addEventListener('click', () => {
+    q.value = '';
+    resultsEl.innerHTML = '';
+    alertsEl.innerHTML = '';
+    q.focus();
+  });
+  q.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter') doSearch();
+  });
+})();

--- a/index.php
+++ b/index.php
@@ -1,0 +1,86 @@
+<?php
+// Simple Anime Meta-Aggregator
+// Tech: PHP + cURL + DOM + HTML/CSS/JS using CDN assets (jsDelivr/cdnjs)
+// Note: Respect each site's Terms of Service and robots.txt. For sites with anti-bot protection,
+// server-side scraping may fail without a headless browser. This project focuses on legal,
+// metadata-only aggregation for discovery (title/thumbnail/link), not re-hosting streams.
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Anime Meta-Aggregator</title>
+  <meta name="description" content="Search anime metadata across multiple providers.">
+  <!-- Bootstrap via jsDelivr -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <!-- Icons via cdnjs -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.3/font/bootstrap-icons.min.css" integrity="sha512-eX+czn6t3M1AHP2s0ayH4B4QZXeGd1tO0t0zY2vW2lqE24nQHA+Nf9PMYGU30sYjJZqSxM7Bf1F+9Qd8Q3qkGg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg bg-dark" data-bs-theme="dark">
+  <div class="container">
+    <a class="navbar-brand" href="/">Anime Hub</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav" aria-controls="nav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div id="nav" class="collapse navbar-collapse">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link active" href="/">Search</a></li>
+        <li class="nav-item"><a class="nav-link" href="README.html" target="_blank">Docs</a></li>
+      </ul>
+      <span class="navbar-text small text-secondary">Demo aggregator · PHP + cURL + DOM</span>
+    </div>
+  </div>
+</nav>
+
+<main class="container my-4">
+  <div class="row g-3 align-items-center">
+    <div class="col-md-8">
+      <input id="q" type="text" class="form-control form-control-lg" placeholder="Search anime (e.g., Bleach, One Piece, Jujutsu Kaisen)">
+    </div>
+    <div class="col-md-2 d-grid">
+      <button id="searchBtn" class="btn btn-primary btn-lg"><i class="bi bi-search"></i> Search</button>
+    </div>
+    <div class="col-md-2 d-grid">
+      <button id="clearBtn" class="btn btn-outline-secondary btn-lg"><i class="bi bi-x-circle"></i> Clear</button>
+    </div>
+  </div>
+
+  <div id="providers" class="my-3">
+    <span class="badge text-bg-secondary me-1">Providers enabled:</span>
+    <span class="badge text-bg-info">Kitsu (API)</span>
+    <span class="badge text-bg-info">Anime News Network (scrape)</span>
+  </div>
+
+  <div id="alerts"></div>
+
+  <div id="results" class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3 mt-2"></div>
+</main>
+
+<footer class="bg-body-tertiary border-top py-4 mt-auto">
+  <div class="container small text-secondary">
+    <div class="d-flex justify-content-between">
+      <div>
+        Built with
+        <a href="https://www.php.net/manual/en/book.curl.php" target="_blank" rel="noopener">PHP cURL</a>,
+        <a href="https://developer.mozilla.org/docs/Web/API/Document_Object_Model" target="_blank" rel="noopener">DOM</a>,
+        <a href="https://getbootstrap.com/" target="_blank" rel="noopener">Bootstrap</a>,
+        <a href="https://cdn.jsdelivr.net/" target="_blank" rel="noopener">jsDelivr</a>,
+        <a href="https://cdnjs.com/" target="_blank" rel="noopener">cdnjs</a>.
+      </div>
+      <div>
+        <a href="README.html" target="_blank" rel="noopener">How it works</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- Axios via cdnjs -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/axios/1.7.2/axios.min.js" integrity="sha512-/N7n2xUeWq1v2gRzseJm3yQKxVIkFIalh4j3E3mDYVeZl8qF4T6L8r3g9i2rVxW9uVIVk9B7mXjXz8cZ6oO2wA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<!-- Bootstrap JS via jsDelivr -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="assets/js/app.js"></script>
+</body>
+</html>

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -1,0 +1,37 @@
+<?php
+
+class Cache
+{
+    private string $dir;
+    private int $ttl;
+
+    public function __construct(string $dir = __DIR__ . '/../.cache', int $ttl = 600)
+    {
+        $this->dir = rtrim($dir, '/');
+        $this->ttl = $ttl;
+        if (!is_dir($this->dir)) {
+            @mkdir($this->dir, 0777, true);
+        }
+    }
+
+    public function get(string $key): ?string
+    {
+        $path = $this->path($key);
+        if (!is_file($path)) return null;
+        if ((time() - filemtime($path)) > $this->ttl) return null;
+        $data = @file_get_contents($path);
+        return $data === false ? null : $data;
+    }
+
+    public function set(string $key, string $value): void
+    {
+        $path = $this->path($key);
+        @file_put_contents($path, $value);
+    }
+
+    private function path(string $key): string
+    {
+        $safe = preg_replace('/[^a-zA-Z0-9_\-\.]/', '_', $key);
+        return "{$this->dir}/{$safe}.cache";
+    }
+}

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -1,0 +1,65 @@
+<?php
+
+class HttpClient
+{
+    private array $defaultHeaders;
+    private int $timeout;
+    private ?string $cookieFile;
+
+    public function __construct(array $headers = [], int $timeout = 15, ?string $cookieFile = null)
+    {
+        $this->defaultHeaders = $headers ?: [
+            'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+            'Accept: text/html,application/json;q=0.9,*/*;q=0.8',
+            'Accept-Language: en-US,en;q=0.9',
+            'Connection: keep-alive',
+        ];
+        $this->timeout = $timeout;
+        $this->cookieFile = $cookieFile;
+    }
+
+    public function get(string $url, array $headers = []): array
+    {
+        return $this->request('GET', $url, null, $headers);
+    }
+
+    public function request(string $method, string $url, ?array $data = null, array $headers = []): array
+    {
+        $ch = curl_init();
+        $opts = [
+            CURLOPT_URL => $url,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_ENCODING => '', // allow all supported encodings (gzip)
+            CURLOPT_MAXREDIRS => 5,
+            CURLOPT_CONNECTTIMEOUT => $this->timeout,
+            CURLOPT_TIMEOUT => $this->timeout,
+            CURLOPT_HTTPHEADER => array_merge($this->defaultHeaders, $headers),
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
+        ];
+        if ($this->cookieFile) {
+            $opts[CURLOPT_COOKIEJAR] = $this->cookieFile;
+            $opts[CURLOPT_COOKIEFILE] = $this->cookieFile;
+        }
+        if (strtoupper($method) !== 'GET') {
+            $opts[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+        }
+        if ($data !== null) {
+            $opts[CURLOPT_POSTFIELDS] = http_build_query($data);
+        }
+        curl_setopt_array($ch, $opts);
+        $body = curl_exec($ch);
+        $err = curl_error($ch);
+        $info = curl_getinfo($ch);
+        curl_close($ch);
+
+        return [
+            'ok' => $err === '' && is_string($body),
+            'status' => (int)($info['http_code'] ?? 0),
+            'headers' => $info,
+            'body' => is_string($body) ? $body : '',
+            'error' => $err,
+        ];
+    }
+}

--- a/providers/ANNProvider.php
+++ b/providers/ANNProvider.php
@@ -1,0 +1,81 @@
+<?php
+require_once __DIR__ . '/../lib/HttpClient.php';
+require_once __DIR__ . '/../lib/Cache.php';
+require_once __DIR__ . '/ProviderInterface.php';
+
+class ANNProvider implements ProviderInterface
+{
+    private HttpClient $http;
+    private Cache $cache;
+
+    public function __construct()
+    {
+        $this->http = new HttpClient([
+            'User-Agent: AnimeHub/1.0 (+https://example.local)',
+            'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',
+        ], 15);
+        $this->cache = new Cache();
+    }
+
+    public function name(): string
+    {
+        return 'AnimeNewsNetwork';
+    }
+
+    public function search(string $query): array
+    {
+        $q = trim($query);
+        if ($q === '') return [];
+        $url = 'https://www.animenewsnetwork.com/encyclopedia/search/name?q=' . rawurlencode($q);
+
+        $cacheKey = 'ann_' . md5($url);
+        $cached = $this->cache->get($cacheKey);
+        $html = $cached;
+        if ($html === null) {
+            $res = $this->http->get($url);
+            if (!$res['ok'] || $res['status'] !== 200) {
+                return [];
+            }
+            $html = $res['body'];
+            $this->cache->set($cacheKey, $html);
+        }
+
+        $doc = new DOMDocument();
+        // Suppress warnings from malformed HTML
+        @$doc->loadHTML($html);
+        $xpath = new DOMXPath($doc);
+
+        // On ANN search results, entries are within .encyc-search-results
+        $nodes = $xpath->query("//div[contains(@class, 'encyc-search-results')]//li/a");
+        $results = [];
+        if ($nodes && $nodes->length > 0) {
+            $count = 0;
+            foreach ($nodes as $a) {
+                $title = trim($a->textContent ?? '');
+                $href = $a->getAttribute('href');
+                if (!$href) continue;
+                $urlFull = $this->absoluteUrl('https://www.animenewsnetwork.com', $href);
+
+                $results[] = [
+                    'title' => $title !== '' ? $title : 'Untitled',
+                    'url' => $urlFull,
+                    'thumbnail' => null, // Not present on search page
+                    'description' => null,
+                    'provider' => $this->name(),
+                ];
+                $count++;
+                if ($count >= 18) break;
+            }
+        }
+
+        return $results;
+    }
+
+    private function absoluteUrl(string $base, string $href): string
+    {
+        if (str_starts_with($href, 'http://') || str_starts_with($href, 'https://')) {
+            return $href;
+        }
+        return rtrim($base, '/') . '/' . ltrim($href, '/');
+    }
+}

--- a/providers/KitsuProvider.php
+++ b/providers/KitsuProvider.php
@@ -1,0 +1,48 @@
+<?php
+require_once __DIR__ . '/../lib/HttpClient.php';
+require_once __DIR__ . '/ProviderInterface.php';
+
+class KitsuProvider implements ProviderInterface
+{
+    private HttpClient $http;
+
+    public function __construct()
+    {
+        $this->http = new HttpClient([
+            'User-Agent: AnimeHub/1.0 (+https://example.local)',
+            'Accept: application/vnd.api+json',
+        ], 12);
+    }
+
+    public function name(): string
+    {
+        return 'Kitsu';
+    }
+
+    public function search(string $query): array
+    {
+        $url = 'https://kitsu.io/api/edge/anime?filter%5Btext%5D=' . rawurlencode($query) . '&page%5Blimit%5D=18';
+        $res = $this->http->get($url);
+        if (!$res['ok'] || $res['status'] !== 200) {
+            return [];
+        }
+        $json = json_decode($res['body'], true);
+        if (!isset($json['data']) || !is_array($json['data'])) {
+            return [];
+        }
+        $out = [];
+        foreach ($json['data'] as $item) {
+            $attr = $item['attributes'] ?? [];
+            $poster = $attr['posterImage']['medium'] ?? ($attr['posterImage']['small'] ?? null);
+            $slug = $attr['slug'] ?? '';
+            $out[] = [
+                'title' => $attr['canonicalTitle'] ?? ($attr['titles']['en'] ?? 'Untitled'),
+                'url' => $slug ? 'https://kitsu.io/anime/' . $slug : 'https://kitsu.io/anime',
+                'thumbnail' => $poster,
+                'description' => $attr['synopsis'] ?? null,
+                'provider' => $this->name(),
+            ];
+        }
+        return $out;
+    }
+}

--- a/providers/ProviderInterface.php
+++ b/providers/ProviderInterface.php
@@ -1,0 +1,17 @@
+<?php
+interface ProviderInterface
+{
+    /**
+     * Search for anime by query.
+     * Returns an array of associative arrays with keys:
+     * - title (string)
+     * - url (string)
+     * - thumbnail (string|null)
+     * - description (string|null)
+     * - provider (string)
+     */
+    public function search(string $query): array;
+
+    /** Provider name */
+    public function name(): string;
+}


### PR DESCRIPTION
This pull request introduces a fully functional Anime Meta-Aggregator, which allows users to search for anime metadata across multiple providers. The following changes have been made:

- **README.html**: Added documentation that explains the project's purpose, features, and how to run it locally.
- **api/search.php**: Implemented API endpoint that aggregates search results from different anime providers (Kitsu and Anime News Network).
- **assets/css/style.css**: Created a minimal custom stylesheet for enhancing UI presentation.
- **assets/js/app.js**: Added JavaScript for handling search functionality and displaying results dynamically.
- **index.php**: Main entry point of the application with integrated search interface and results display.
- **lib/Cache.php**: Implemented caching mechanism to store search results temporarily, improving performance.
- **lib/HttpClient.php**: Created HTTP client for making network requests with support for custom headers and timeouts.
- **providers/ANNProvider.php**: Added provider for scraping data from Anime News Network.
- **providers/KitsuProvider.php**: Added provider to utilize Kitsu API for fetching anime data.
- **providers/ProviderInterface.php**: Defined a common interface for all providers to ensure consistent implementation.

---

> This pull request was co-created with Cosine Genie

Original Task: [Jrmsite/s885aax2381r](https://cosine.sh/tyy0ca6kz5pn/Jrmsite/task/s885aax2381r)
Author: Jhames Martin
